### PR TITLE
Add Convos::Upgrader namespace: Migration helper for convos

### DIFF
--- a/lib/Convos/Upgrader.pm
+++ b/lib/Convos/Upgrader.pm
@@ -1,0 +1,125 @@
+package Convos::Upgrader;
+
+=head1 NAME
+
+Convos::Upgrader - Apply changes from one convos version to another
+
+=head1 DESCRIPTION
+
+This class can to upgrade the convos database from one version to another.
+
+The upgrade is done by fetching the current version that is stored in the
+database and run the steps from the version after and up to the lastest
+version available. Each step is described in the L<Convos::Upgrader|/STEPS>
+namespace.
+
+=head1 STEPS
+
+=over 4
+
+=item * L<Convos::Upgrader::s0_3002>
+
+=back
+
+=cut
+
+use Mojo::Base 'Mojo::EventEmitter';
+use Mojo::Loader;
+use Mojo::Redis;
+
+=head1 EVENTS
+
+=head2 error
+
+  $self->on(error => sub { my($self, $msg) = @_; });
+
+Emitted if the upgrade fail.
+
+=head2 finish
+
+  $self->on(finish => sub { my($self, $msg) = @_; });
+
+Emitted when the upgrade was completed.
+
+=head1 ATTRIBUTES
+
+=head2 redis
+
+Holds a L<Mojo::Redis> object. Required in constructor to avoid migrating the
+wrong database.
+
+=cut
+
+has redis => undef;
+has _loader => sub { Mojo::Loader->new };
+
+=head1 METHODS
+
+=head2 run
+
+This method will check the current database version and run upgrade steps
+to the wanted version.
+
+=cut
+
+sub run {
+  my($self, $cb) = @_;
+
+  $self->redis->get('convos:version', sub {
+    my($redis, $current) = @_;
+    $self->{steps} = $self->_steps($current);
+    $self->_next;
+  });
+
+  $self;
+}
+
+sub _finish {
+  my $self = shift;
+
+  return $self->emit(finish => "Database schema has latest version.") unless $self->{version};
+  return $self->redis->set('convos:version', $self->{version}, sub {
+    $self->emit(finish => "Upgraded database to $self->{version} through $self->{stepped} steps.");
+  });
+}
+
+sub _next {
+  my $self = shift;
+  my $step = shift @{ $self->{steps} } or return $self->_finish;
+
+  $step->on(finish => sub { $self->{stepped}++; $self->_next; });
+  $step->on(error => sub { $self->error(pop); });
+  $step->_run;
+}
+
+sub _steps {
+  my $self = shift;
+  my $current = shift || 0;
+  my $loader = $self->_loader;
+  my @steps;
+
+  for my $class (sort @{ $loader->search('Convos::Upgrader') }) {
+    my $v = $self->_version_from_class($class) or next;
+    my $e;
+    $v <= $current and next;
+    $e = $loader->load($class) and $self->emit(error => $e) and next;
+    push @steps, $class->new(redis => $self->redis, version => $v);
+    $self->{version} = $v;
+  }
+
+  return \@steps;
+}
+
+sub _version_from_class {
+  my $v = $_[1] =~ /::s(\d.*)/ ? $1 : 0;
+  $v =~ s/_/\./;
+  $v;
+}
+
+=head1 AUTHOR
+
+Jan Henning Thorsen - C<jhthorsen@cpan.org>
+
+=cut
+
+1;

--- a/lib/Convos/Upgrader/s0_3002.pm
+++ b/lib/Convos/Upgrader/s0_3002.pm
@@ -1,0 +1,27 @@
+package Convos::Upgrader::s0_3002;
+
+=head1 NAME
+
+Convos::Upgrader::s0_3002 - Upgrade instructions to version 0.3002
+
+=head1 DESCRIPTION
+
+This is currently a dummy module to make the unittest do anything.
+
+=cut
+
+use Mojo::Base 'Convos::Upgrader';
+
+sub _run {
+  my $self = shift;
+
+  $self->emit('finish');
+}
+
+=head1 AUTHOR
+
+Jan Henning Thorsen - C<jhthorsen@cpan.org>
+
+=cut
+
+1;

--- a/t/Helper.pm
+++ b/t/Helper.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Mojo;
+use Mojo::Redis;
 
 BEGIN {
   $ENV{MOJO_MODE} = 'testing';
@@ -10,11 +11,11 @@ BEGIN {
   $ENV{REDIS_TEST_DATABASE} ||= '';
 }
 
-my $t;
+my($redis, $t);
 
 sub redis_do {
   my $delay = Mojo::IOLoop->delay;
-  my $redis = $t->app->redis;
+  my $redis = $redis || $t->app->redis;
   $redis->execute(@_, $delay->begin);
   $delay->wait;
 }
@@ -34,6 +35,7 @@ sub wait_a_bit {
 
 sub import {
   my $class = shift;
+  my $no_web = grep { /no_web/ } @_;
   my $caller = caller;
   my $keys;
 
@@ -42,10 +44,15 @@ sub import {
   $ENV{REDIS_TEST_DATABASE} = 'redis://127.0.0.1:6379/14' if $ENV{REDIS_TEST_DATABASE} eq 'default';
 
   # make sure we use our own test database
-  $t = Test::Mojo->new('Convos');
-  $t->app->config(redis => $ENV{REDIS_TEST_DATABASE});
-  $t->app->core->redis->server eq $ENV{REDIS_TEST_DATABASE} or die;
-  $t->app->redis->server eq $ENV{REDIS_TEST_DATABASE} or die;
+  if($no_web) {
+    $redis = Mojo::Redis->new(server => $ENV{REDIS_TEST_DATABASE});
+  }
+  else {
+    $t = Test::Mojo->new('Convos');
+    $t->app->config(redis => $ENV{REDIS_TEST_DATABASE});
+    $t->app->core->redis->server eq $ENV{REDIS_TEST_DATABASE} or die;
+    $t->app->redis->server eq $ENV{REDIS_TEST_DATABASE} or die;
+  }
 
   redis_do('flushdb') unless $ENV{KEEP_REDIS};
 

--- a/t/upgrader.t
+++ b/t/upgrader.t
@@ -1,0 +1,26 @@
+use t::Helper qw( no_web );
+use Convos::Upgrader;
+
+plan skip_all => 'Live tests skipped. Set REDIS_TEST_DATABASE to "default" for db #14 on localhost or a redis:// url for custom.' unless $ENV{REDIS_TEST_DATABASE};
+
+my $upgrader = Convos::Upgrader->new;
+my($finish, $err);
+
+{
+  redis_do(del => 'convos:version');
+  redis_do(set => 'convos:version', $ENV{CONVOS_VERSION}) if $ENV{CONVOS_VERSION};
+}
+
+{
+  $upgrader->redis(Mojo::Redis->new(server => $ENV{REDIS_TEST_DATABASE}));
+  $upgrader->on(error => sub { $err = pop; Mojo::IOLoop->stop; });
+  $upgrader->on(finish => sub { $finish = 1; Mojo::IOLoop->stop; });
+  $upgrader->run;
+  Mojo::IOLoop->start;
+
+  is $finish, 1, 'finishd';
+  is $err, undef, 'no error';
+  is redis_do(get => 'convos:version'), '0.3002', 'convos:version is set';
+}
+
+done_testing;


### PR DESCRIPTION
The change from /:server/:target to just /:conversation_name (that change does not have a pull request yet) require database change to make the URL prettier. I'm thinking adding classes that describe each upgrade step is a good idea.
