### PR TITLE
Added IO::Socket::SSL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ run    apt-get --yes upgrade --force-yes
 run    apt-get install -y -q software-properties-common
 run    add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
 
-run apt-get -y install curl perl supervisor redis-server make rubygems
+run apt-get -y install curl perl supervisor redis-server make rubygems libio-socket-ssl-perl
 add ./vendor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 add . /convos
 run gem install sass
 run cd /convos; ./vendor/bin/carton
-expose 8080 
+expose 8080
 entrypoint ["/usr/bin/supervisord"]


### PR DESCRIPTION
Encrypted connections were not possible with the Docker version as IO::Socket::SSL was missing.
Fixes #67.
