### PR TITLE
A few little Dockerfile tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN gem install sass
 RUN cd /convos; ./vendor/bin/carton
 
 ENV MOJO_MODE production
+ENV CONVOS_REDIS_URL redis://127.0.0.1:6379/1
 
 EXPOSE 8080
 ENTRYPOINT ["/usr/bin/supervisord"]


### PR DESCRIPTION
- Setting `ENV DEBIAN_FRONTEND noninteractive` is not recommended (see Note here: http://docs.docker.io/reference/builder/#env).
- Universe repository is already added in upstream image.
- A few tweaks from http://crosbymichael.com/dockerfile-best-practices-take-2.html (apt-get upgrade in upstream, grouping of install for better caching).
