### PR TITLE
Add timestamp to every message

### DIFF
--- a/templates/event/action_message.html.ep
+++ b/templates/event/action_message.html.ep
@@ -4,9 +4,7 @@
   %= avatar { nick => $nick, host => $host, user => $user }, alt => $nick, class => 'avatar'
 % }
   <div class="content whitespace">&#10023; <%= link_to $nick, view => { network => $network, target => $nick } %> <%== $message %></div>
-% if($nick ne $prev_nick) {
-  %= timestamp_span($timestamp)
-% }
+  %= timestamp_span $timestamp
 % if(my $embed = stash 'embed') {
   <div class="embed"><%== $embed %></div>
 % }

--- a/templates/event/message.html.ep
+++ b/templates/event/message.html.ep
@@ -9,9 +9,7 @@
   % }
 % }
   <div class="content whitespace"><%== $message %></div>
-% if($nick ne $prev_nick) {
-  %= timestamp_span($timestamp)
-% }
+  %= timestamp_span $timestamp
 % if(my $embed = stash 'embed') {
   <div class="embed"><%== $embed %></div>
 % }


### PR DESCRIPTION
It's annoying not having a timestamp on every message when you're in a channel where people are not very active.
