### PR TITLE
Docker fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ADD . /convos
 RUN gem install sass
 RUN cd /convos; ./vendor/bin/carton
 
-ENV MOJO_LISTEN "http://*:8080"
+ENV MOJO_LISTEN http://*:8080
 ENV MOJO_MODE production
 ENV MOJO_REVERSE_PROXY 0
 ENV CONVOS_REDIS_URL redis://127.0.0.1:6379/1


### PR DESCRIPTION
With latest Docker the container did no longer start. Fixes:
- "Can't create listen socket: IO::Socket::INET: Bad hostname '*:8080"' at /convos/local/lib/perl5/Mojo/IOLoop.pm line 120." issue and
- "Error: positional arguments are not supported For help, use /usr/bin/supervisord -h" problem.
