### PR TITLE
Preserve half done messages in history with arrow down

### DIFF
--- a/public/js/convos.input.js
+++ b/public/js/convos.input.js
@@ -88,8 +88,16 @@
     });
     convos.input.bind('keydown', 'down', function(e) {
       e.preventDefault();
-      if (++history.i == history.length) return convos.input.val(this.current_input_str);
-      if (history.i > history.length) return history.i = history.length;
+      if (history.i === history.length) {
+        if (convos.input.val().length) {
+          history[history.i++]=convos.input.val();
+          convos.input.val('');
+        }
+        return;
+      }
+      if (++history.i === history.length) {
+        return convos.input.val(this.current_input_str);
+      }
       convos.input.val(history[history.i]);
     });
     convos.input.closest('form').on('submit', function(e) {


### PR DESCRIPTION
This fixes #151, so that half-done messages are saved to history
on arrow down. It also ensures that the history index pointer doesn't 
get increased if you keep pressing arrow down at the end of the history.
