### PR TITLE
fixed convos-backend startup command

### DIFF
--- a/vendor/supervisord.conf
+++ b/vendor/supervisord.conf
@@ -23,7 +23,7 @@ autorestart=true
 
 [program:convos-backend]
 directory=/convos
-command=/convos/vendor/bin/carton exec script/convos backend
+command=/convos/vendor/bin/carton exec script/convos backend foreground
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true


### PR DESCRIPTION
for supervisord (and thus Dockerfile)

without this fix, 

``` bash
command=/convos/vendor/bin/carton exec script/convos backend
```

returns

```
Usage: convos backend {start|stop|reload|restart|foreground|status|get_init_file}
```
