### PR TITLE
Update commands.js

### DIFF
--- a/assets/js/commands.js
+++ b/assets/js/commands.js
@@ -45,10 +45,10 @@ add('/clear', '/clear history <#channel> or /clear history <nick>', 'Delete all 
 add('/oper', '/oper <nick> <password>', 'Gain operator status on a network.');
 add('/cs', '/cs <msg>', 'Send a message to chanserv.');
 add('/ns', '/ns <msg>', 'Send a message to nickserv.');
-add('/ms', '/ms <msg>', 'Send a message to memoserv');
-add('/hs', '/hs <msg>', 'Send a message to hostserv');
-add('/bs', '/bs <msg>', 'Send a message to botserv');
-add('/os', '/os <msg>', 'Send a message to operserv');
+add('/ms', '/ms <msg>', 'Send a message to memoserv.');
+add('/hs', '/hs <msg>', 'Send a message to hostserv.');
+add('/bs', '/bs <msg>', 'Send a message to botserv.');
+add('/os', '/os <msg>', 'Send a message to operserv.');
 add('/quote', '/quote <irc-command>', 'Allow you to send any raw IRC message.');
 
 const rewrite = (from, to) => (rewriteRule[from] = to);

--- a/assets/js/commands.js
+++ b/assets/js/commands.js
@@ -45,13 +45,22 @@ add('/clear', '/clear history <#channel> or /clear history <nick>', 'Delete all 
 add('/oper', '/oper <msg>', 'Send server operator messages.');
 add('/cs', '/cs <msg>', 'Send a message to chanserv.');
 add('/ns', '/ns <msg>', 'Send a message to nickserv.');
+add('/ms', '/ms <msg>', 'Send a message to memoserv');
+add('/hs', '/hs <msg>', 'Send a message to hostserv');
+add('/bs', '/bs <msg>', 'Send a message to botserv');
+add('/os', '/os <msg>', 'Send a message to operserv');
 add('/quote', '/quote <irc-command>', 'Allow you to send any raw IRC message.');
 
 const rewrite = (from, to) => (rewriteRule[from] = to);
 
 rewrite('/close', '/part');
 rewrite('/shrug', (parts) => '/say ' + parts.concat('¯\\_(ツ)_/¯').join(' '));
-rewrite('/cs', '/msg chanserv');
+rewrite('/cs', '/quote chanserv');
+rewrite('/ns', '/quote nickserv');
+rewrite('/ms', '/quote memoserv');
+rewrite('/hs', '/quote hotserv');
+rewrite('/bs', '/quote botserv');
+rewrite('/os', '/quote operserv');
 rewrite('/j', '/join');
 rewrite('/ns', '/msg nickserv');
 rewrite('/raw', '/quote');

--- a/assets/js/commands.js
+++ b/assets/js/commands.js
@@ -42,7 +42,7 @@ add('/names', '/names', 'Show participants in the channel.');
 add('/invite', '/invite <nick> [#channel]', 'Invite a user to a channel.');
 add('/reconnect', '/reconnect', 'Restart the current connection.');
 add('/clear', '/clear history <#channel> or /clear history <nick>', 'Delete all history for the given conversation.');
-add('/oper', '/oper <msg>', 'Send server operator messages.');
+add('/oper', '/oper <nick> <password>', 'Gain operator status on a network.');
 add('/cs', '/cs <msg>', 'Send a message to chanserv.');
 add('/ns', '/ns <msg>', 'Send a message to nickserv.');
 add('/ms', '/ms <msg>', 'Send a message to memoserv');

--- a/assets/js/commands.js
+++ b/assets/js/commands.js
@@ -62,5 +62,4 @@ rewrite('/hs', '/quote hotserv');
 rewrite('/bs', '/quote botserv');
 rewrite('/os', '/quote operserv');
 rewrite('/j', '/join');
-rewrite('/ns', '/msg nickserv');
 rewrite('/raw', '/quote');


### PR DESCRIPTION
- Added support for some other services such as MemoServ, BotServ, HostServ and OperServ
- Changed the rewrite from "/msg target" to "/quote target" which makes Convos aliases work out of the box on DALnet which forces the users to address themselves to services with "/msg NickServ@services.dal.net", e.g. Using "/quote" instead "/msg" solves that issue.