### PR TITLE
Add GNOME dark theme

### DIFF
--- a/public/themes/gnome_color-scheme-dark.css
+++ b/public/themes/gnome_color-scheme-dark.css
@@ -29,7 +29,6 @@
   --input-color: #fff;
   --input-focus-outline: 2px solid #15539e;
   --input-disabled-bg: #2d2d2d;
-  --input-disabled-color: #D8DEE9;
   --chat-input-bg: #353535;
   --autocomplete-bg: #353535;
   --autocomplete-border: 1px solid #1b1b1b;

--- a/public/themes/gnome_color-scheme-dark.css
+++ b/public/themes/gnome_color-scheme-dark.css
@@ -30,7 +30,7 @@
   --input-focus-outline: 2px solid #15539e;
   --input-disabled-bg: #2d2d2d;
   --input-disabled-color: #D8DEE9;
-  --chat-input-bg: #2d2d2d;
+  --chat-input-bg: #353535;
   --autocomplete-bg: #353535;
   --autocomplete-border: 1px solid #1b1b1b;
   --autocomplete-focus-bg: #15539e;
@@ -43,10 +43,6 @@
   --sidebar-right-bg: var(--body-bg);
   --sidebar-right-text: var(--text-color);
   --syntax-hl-base-bg: #353535;
-}
-
-.chat-input {
-  background: #353535;
 }
 
 .sidebar-left__nav > h3 {

--- a/public/themes/gnome_color-scheme-dark.css
+++ b/public/themes/gnome_color-scheme-dark.css
@@ -1,0 +1,58 @@
+/*
+ * name: GNOME
+ * color-scheme: dark
+ */
+
+:root {
+  --body-bg: #2d2d2d;
+  --cms-bg: var(--body-bg);
+  --text-color: #fff;
+  --link-color: #3472bd;
+  --quote-color: #3472bd;
+  --error-color: #ae151c;
+  --success-color: #0f3b71;
+  --highlight-color-bg: #353535;
+  --highlight-color: #fff;
+  --hr-border: 1px solid #1b1b1b;
+  --button-bg: #343434;
+  --code-bg: #292929;
+  --button-color: #ECEFF4;
+  --button-border: 1px solid #1b1b1b;
+  --button-focus-outline: 2px solid #1b1b1b;
+  --button-disabled-bg: #323232;
+  --button-disabled-color: #eceff4;
+  --button-disabled-border: #1b1b1b;
+  --button-danger-bg: #ae151c;
+  --button-danger-color: #fff;
+  --input-bg: #2d2d2d;
+  --input-border: 1px solid #1b1b1b;
+  --input-color: #fff;
+  --input-focus-outline: 2px solid #15539e;
+  --input-disabled-bg: #2d2d2d;
+  --input-disabled-color: #D8DEE9;
+  --chat-input-bg: #2d2d2d;
+  --autocomplete-bg: #353535;
+  --autocomplete-border: 1px solid #1b1b1b;
+  --autocomplete-focus-bg: #15539e;
+  --ts-color: #919190;
+  --sidebar-left-bg: #313131;
+  --sidebar-left-text: #fff;
+  --sidebar-left-border-bottom: #1b1b1b;
+  --sidebar-left-search-placeholder-color: #fff;
+  --sidebar-left-search-focus-bg: #15539e;
+  --sidebar-right-bg: var(--body-bg);
+  --sidebar-right-text: var(--text-color);
+  --syntax-hl-base-bg: #353535;
+}
+
+.chat-input {
+  background: #353535;
+}
+
+.sidebar-left__nav > h3 {
+  color: #919190;
+}
+
+body.for-cms {
+  --footer-bg: var(--sidebar-left-bg);
+}

--- a/public/themes/gnome_color-scheme-dark.css
+++ b/public/themes/gnome_color-scheme-dark.css
@@ -24,7 +24,7 @@
   --button-disabled-border: #1b1b1b;
   --button-danger-bg: #ae151c;
   --button-danger-color: #fff;
-  --input-bg: #2d2d2d;
+  --input-bg: #353535;
   --input-border: 1px solid #1b1b1b;
   --input-color: #fff;
   --input-focus-outline: 2px solid #15539e;


### PR DESCRIPTION
## Description

I originally made this theme as I'm a GNOME user and wanted something that fitted in with it's theming. I used [Fractal](https://gitlab.gnome.org/GNOME/fractal) and `gtk3-widget-factory` with GNOME dark theming enabled for reference. I made this a few weeks ago and have been using it since and haven't noticed any issues. I apologise if the css isn't great.

I'm not sure if you want to keep the `color-scheme: dark` and `-dark.css` in the filename, but originally when I wrote this I'd planned to make a light theme too, since that is the default for GNOME, but I never got around to it.

## Screenshots

![Screenshot from 2021-05-25 20-48-14](https://user-images.githubusercontent.com/7016957/119489569-5919ec00-bd4b-11eb-9ac2-bf6ceba913f8.png)
![Screenshot from 2021-05-25 17-56-56](https://user-images.githubusercontent.com/7016957/119489627-6636db00-bd4b-11eb-8d0b-92ede8e546d1.png)
![Screenshot from 2021-05-25 17-57-14](https://user-images.githubusercontent.com/7016957/119489639-6931cb80-bd4b-11eb-9b95-bd5eab30a73d.png)