### PR TITLE
Fix very bright preformatted message background in "Hacker" theme

### DIFF
--- a/public/themes/hacker.css
+++ b/public/themes/hacker.css
@@ -54,7 +54,7 @@
   /* Keep as is */
   --error-color: #ee2222;
   --success-color: #338833;
-  --syntax-hl-base-bg: #fff;
+  --syntax-hl-base-bg: black;
 
   /* Listbox */
   --autocomplete-bg: #181818;


### PR DESCRIPTION
This PR turns this

![bright](https://user-images.githubusercontent.com/1942208/119968430-be6d1780-bfad-11eb-8bb0-ba6c63e528e9.png)

into this

![dark](https://user-images.githubusercontent.com/1942208/119968452-c6c55280-bfad-11eb-8df2-5fd2894e6d62.png)

Preformatted messaged will be less blinding but also not as distinguishable from other messages as before.