### PR TITLE
Castaway/dismiss notifications in channel

### DIFF
--- a/__tests__/store/Notifications.js
+++ b/__tests__/store/Notifications.js
@@ -18,10 +18,7 @@ test('addMessages', () => {
   let c = new Notifications({});
 
   c.addMessages([{message: ''}]);
-  expect(c.unread).toBe(0);
-
   c.addMessages({message: 'cool beans'});
-  expect(c.unread).toBe(1);
   expect(c.messages.length).toBe(2);
 });
 

--- a/__tests__/store/User.js
+++ b/__tests__/store/User.js
@@ -97,6 +97,7 @@ test('load success', async () => {
   expect(user.email).toBe('');
   expect(user.forced_connection).toBe(false);
   expect(user.highlightKeywords).toEqual([]);
+  expect(user.notifications.unread).toBe(0);
 
   // Get response
   socket.ws.dispatchEvent('message', {
@@ -117,6 +118,11 @@ test('load success', async () => {
   expect(user.forced_connection).toBe(true);
   expect(user.highlightKeywords).toEqual(['foo', 'bar']);
   expect(user.status).toBe('success');
+
+  // Notfications
+  expect(user.notifications.unread).toBe(0);
+  user.updateNotificationCount();
+  expect(user.notifications.unread).toBe(0);
 });
 
 test('load error', async () => {

--- a/assets/components/ChatSidebar.svelte
+++ b/assets/components/ChatSidebar.svelte
@@ -11,6 +11,7 @@ import {route} from '../store/Route';
 export let transition;
 
 const user = getContext('user');
+const notifications = user.notifications;
 
 let activeLinkIndex = 0;
 let filter = '';
@@ -19,7 +20,6 @@ let searchHasFocus = false;
 let visibleLinks = [];
 
 $: filterNav({filter}); // Passing "filter" in to make sure filterNav() is called on change
-$: notifications = $user.notifications;
 $: addConversationLink = '/settings/conversation?connection_id=' + ($user.activeConversation.connection_id || '');
 $: searchQuery = filter.replace(/^\//, '');
 $: if (navEl) clearFilter($route);

--- a/assets/components/ChatSidebar.svelte
+++ b/assets/components/ChatSidebar.svelte
@@ -11,7 +11,6 @@ import {route} from '../store/Route';
 export let transition;
 
 const user = getContext('user');
-const notifications = $user.notifications;
 
 let activeLinkIndex = 0;
 let filter = '';
@@ -20,6 +19,7 @@ let searchHasFocus = false;
 let visibleLinks = [];
 
 $: filterNav({filter}); // Passing "filter" in to make sure filterNav() is called on change
+$: notifications = $user.notifications;
 $: addConversationLink = '/settings/conversation?connection_id=' + ($user.activeConversation.connection_id || '');
 $: searchQuery = filter.replace(/^\//, '');
 $: if (navEl) clearFilter($route);

--- a/assets/page/Chat.svelte
+++ b/assets/page/Chat.svelte
@@ -39,6 +39,7 @@ let focusChatInput, fillIn, uploader;
 
 $: setConversationFromRoute(connection_id, conversation_id);
 $: setConversationFromUser($user);
+$: updateNotificationCount($user);
 $: messages.update({expandUrlToMedia: $user.expandUrlToMedia});
 $: notConnected = $conversation.frozen ? true : false;
 $: title = $conversation.title;
@@ -97,6 +98,11 @@ function showPopover(e) {
       if (!$popoverTarget) target.click();
     }
   }, 250);
+}
+
+function updateNotificationCount(user) {
+  user.activeConversation.update({notifications: 0});
+  user.updateNotificationCount();
 }
 </script>
 

--- a/assets/page/Chat.svelte
+++ b/assets/page/Chat.svelte
@@ -39,7 +39,6 @@ let focusChatInput, fillIn, uploader;
 
 $: setConversationFromRoute(connection_id, conversation_id);
 $: setConversationFromUser($user);
-$: updateNotificationCount($user);
 $: messages.update({expandUrlToMedia: $user.expandUrlToMedia});
 $: notConnected = $conversation.frozen ? true : false;
 $: title = $conversation.title;
@@ -82,6 +81,7 @@ function setConversationFromUser(user) {
   now = new Time();
   unsubscribe.conversation = conversation.subscribe(d => { conversation = d });
   unsubscribe.markAsRead = conversation.markAsRead.bind(conversation);
+  updateNotificationCount(user);
 
   onLoadHash = isISOTimeString(route.hash) && route.hash || '';
   if (onLoadHash) return conversation.load({around: onLoadHash});

--- a/assets/page/Notifications.svelte
+++ b/assets/page/Notifications.svelte
@@ -15,7 +15,7 @@ const conversation = user.notifications;
 $: classNames = ['main', messages.length && 'has-results'].filter(i => i);
 $: messages = $conversation.messages;
 
-onDestroy(() => conversation.markAsRead());
+onDestroy(() => { user.markNotificationsRead(); conversation.markAsRead() });
 onMount(() => conversation.load());
 </script>
 

--- a/assets/page/Notifications.svelte
+++ b/assets/page/Notifications.svelte
@@ -15,7 +15,7 @@ const conversation = user.notifications;
 $: classNames = ['main', messages.length && 'has-results'].filter(i => i);
 $: messages = $conversation.messages;
 
-onDestroy(() => { user.markNotificationsRead(); conversation.markAsRead() });
+  onDestroy(() => user.markNotificationsRead(); });
 onMount(() => conversation.load());
 </script>
 

--- a/assets/store/Conversation.js
+++ b/assets/store/Conversation.js
@@ -32,6 +32,7 @@ export default class Conversation extends Reactive {
     this.prop('rw', 'status', 'pending');
     this.prop('rw', 'topic', params.topic || '');
     this.prop('rw', 'unread', params.unread || 0);
+    this.prop('rw', 'notifications', params.notifications || 0);
 
     if (params.hasOwnProperty('conversation_id')) {
       this.prop('ro', 'conversation_id', params.conversation_id);

--- a/assets/store/Conversation.js
+++ b/assets/store/Conversation.js
@@ -29,10 +29,10 @@ export default class Conversation extends Reactive {
     this.prop('rw', 'historyStopAt', null);
     this.prop('rw', 'modes', {});
     this.prop('rw', 'name', params.name || params.conversation_id || params.connection_id || 'ERR');
+    this.prop('rw', 'notifications', params.notifications || 0);
     this.prop('rw', 'status', 'pending');
     this.prop('rw', 'topic', params.topic || '');
     this.prop('rw', 'unread', params.unread || 0);
-    this.prop('rw', 'notifications', params.notifications || 0);
 
     if (params.hasOwnProperty('conversation_id')) {
       this.prop('ro', 'conversation_id', params.conversation_id);

--- a/assets/store/Notifications.js
+++ b/assets/store/Notifications.js
@@ -8,13 +8,13 @@ export default class Notifications extends Conversation {
       connection_id: '',
       conversation_id: 'notifications',
       name: 'Notifications',
+      unread: 0,
     });
   }
 
   addMessages(messages, method) {
     if (!Array.isArray(messages)) {
       messages = [messages];
-      this.update({unread: this.unread + 1});
     }
 
     this.messages.push(messages);

--- a/assets/store/User.js
+++ b/assets/store/User.js
@@ -121,6 +121,7 @@ export default class User extends Reactive {
 
   markNotificationsRead() {
     this.conversations().forEach(conv => conv.update({notifications: 0}));
+    user.activeConversation.markAsRead();
   }
 
   removeConversation(params) {

--- a/assets/store/User.js
+++ b/assets/store/User.js
@@ -119,6 +119,10 @@ export default class User extends Reactive {
     });
   }
 
+  markNotificationsRead() {
+    this.conversations().forEach(conv => conv.update({notifications: 0}));
+  }
+
   removeConversation(params) {
     const conn = this.findConversation({connection_id: params.connection_id});
     if (params.conversation_id) return conn && conn.removeConversation(params);

--- a/lib/Convos/Controller/Conversation.pm
+++ b/lib/Convos/Controller/Conversation.pm
@@ -9,7 +9,7 @@ sub mark_as_read {
   my $conversation = $self->backend->conversation({});
 
   unless ($conversation) {
-    return $self->reply->errors([],                        401) unless $self->backend->user;
+    return $self->reply->errors([], 401) unless $self->backend->user;
     return $self->reply->errors('Conversation not found.', 404);
   }
 
@@ -21,7 +21,7 @@ sub mark_as_read {
 
 sub list {
   my $self = shift->openapi->valid_input or return;
-  my $user = $self->backend->user        or return $self->reply->errors([], 401);
+  my $user = $self->backend->user or return $self->reply->errors([], 401);
   my @conversations;
 
   for my $connection (sort { $a->name cmp $b->name } @{$user->connections}) {

--- a/lib/Convos/Controller/Conversation.pm
+++ b/lib/Convos/Controller/Conversation.pm
@@ -13,8 +13,7 @@ sub mark_as_read {
     return $self->reply->errors('Conversation not found.', 404);
   }
 
-  $conversation->unread(0);
-  $conversation->notifications(0);
+  $conversation->notifications(0)->unread(0);
   $self->stash('connection')->save_p->then(sub {
     $self->render(openapi => {});
   });

--- a/lib/Convos/Controller/Conversation.pm
+++ b/lib/Convos/Controller/Conversation.pm
@@ -14,6 +14,7 @@ sub mark_as_read {
   }
 
   $conversation->unread(0);
+  $conversation->notifications(0);
   $self->stash('connection')->save_p->then(sub {
     $self->render(openapi => {});
   });

--- a/lib/Convos/Controller/Notifications.pm
+++ b/lib/Convos/Controller/Notifications.pm
@@ -16,12 +16,8 @@ sub read {
   my $self = shift->openapi->valid_input or return;
   my $user = $self->backend->user        or return $self->reply->errors([], 401);
 
-  Mojo::Promise->all($user->connections->map(sub {
-      my $conn = shift;
-      $conn->conversations->map( sub { shift->notifications(0); });
-      $conn->save_p();
-    })
-  )->then(sub { $self->render(openapi => {}) });
+  $user->connections->map( sub { shift->conversations->map( notifications => 0 ) });
+  $self->render(openapi => {});
 }
 
 1;

--- a/lib/Convos/Controller/Notifications.pm
+++ b/lib/Convos/Controller/Notifications.pm
@@ -14,9 +14,9 @@ sub messages {
 
 sub read {
   my $self = shift->openapi->valid_input or return;
-  my $user = $self->backend->user        or return $self->reply->errors([], 401);
+  my $user = $self->backend->user or return $self->reply->errors([], 401);
 
-  $user->connections->map( sub { shift->conversations->map( notifications => 0 ) });
+  $user->connections->map(sub { shift->conversations->map(notifications => 0) });
   $self->render(openapi => {});
 }
 

--- a/lib/Convos/Core/Backend.pm
+++ b/lib/Convos/Core/Backend.pm
@@ -75,7 +75,7 @@ sub _setup {
           my ($connection, $target, $msg) = @_;
 
           if ($msg->{highlight} and $target->id and !$target->is_private) {
-            $connection->user->{unread}++;
+            $target->inc_notifications_p->catch(sub { $self->_debug('inc_notifications %s FAIL %s', $target->id, shift) } );
           }
 
           $self->emit("user:$uid",

--- a/lib/Convos/Core/Backend.pm
+++ b/lib/Convos/Core/Backend.pm
@@ -75,7 +75,7 @@ sub _setup {
           my ($connection, $target, $msg) = @_;
 
           if ($msg->{highlight} and $target->id and !$target->is_private) {
-            $target->inc_notifications_p->catch(sub { $self->_debug('inc_notifications %s FAIL %s', $target->id, shift) } );
+            $target->inc_notifications();
           }
 
           $self->emit("user:$uid",

--- a/lib/Convos/Core/Conversation.pm
+++ b/lib/Convos/Core/Conversation.pm
@@ -4,12 +4,12 @@ use Mojo::Base -base;
 use Convos::Util '$CHANNEL_RE';
 use Mojo::Date;
 
-has frozen   => '';
-has name     => sub { Carp::confess('name required in constructor') };
-has password => '';
-has topic    => '';
-has unread   => 0;
+has frozen        => '';
+has name          => sub { Carp::confess('name required in constructor') };
+has password      => '';
 has notifications => 0;
+has topic         => '';
+has unread        => 0;
 
 sub connection { shift->{connection} or Carp::confess('connection required in constructor') }
 sub id         { my $from = $_[1] || $_[0]; lc($from->{id} // $from->{name}) }

--- a/lib/Convos/Core/Conversation.pm
+++ b/lib/Convos/Core/Conversation.pm
@@ -21,11 +21,7 @@ sub inc_unread_p {
   return Mojo::Promise->resolve($self);
 }
 
-sub inc_notifications_p {
-  my $self = shift;
-  $self->{notifications}++;
-  return Mojo::Promise->resolve($self);
-}
+sub inc_notifications { $_[0]->{notifications}++; $_[0] }
 
 sub messages_p {
   my ($self, $query) = @_;
@@ -121,9 +117,9 @@ Holds the number of unread notifications.
 
 Used to increase the unread count.
 
-=head2 inc_notifications_p
+=head2 inc_notifications
 
-  $p = $conversation->inc_notifications_p;
+  $p = $conversation->inc_notifications;
 
 Used to increate the unread notifications count.
 

--- a/lib/Convos/Core/Conversation.pm
+++ b/lib/Convos/Core/Conversation.pm
@@ -9,6 +9,7 @@ has name     => sub { Carp::confess('name required in constructor') };
 has password => '';
 has topic    => '';
 has unread   => 0;
+has notifications => 0;
 
 sub connection { shift->{connection} or Carp::confess('connection required in constructor') }
 sub id         { my $from = $_[1] || $_[0]; lc($from->{id} // $from->{name}) }
@@ -17,6 +18,12 @@ sub is_private { shift->name =~ /^$CHANNEL_RE/ ? 0 : 1 }
 sub inc_unread_p {
   my $self = shift;
   $self->{unread}++;
+  return Mojo::Promise->resolve($self);
+}
+
+sub inc_notifications_p {
+  my $self = shift;
+  $self->{notifications}++;
   return Mojo::Promise->resolve($self);
 }
 
@@ -35,7 +42,7 @@ sub _calculate_unread_p {
 
 sub TO_JSON {
   my ($self, $persist) = @_;
-  my %json = map { ($_, $self->$_) } qw(frozen name topic unread);
+  my %json = map { ($_, $self->$_) } qw(frozen name topic unread notifications);
   $json{connection_id}   = $self->connection->id;
   $json{conversation_id} = $self->id;
   $json{last_read}       = $self->{last_read} if $self->{last_read};    # back compat
@@ -100,6 +107,12 @@ The topic (subject) of the conversation.
 
 Holds the number of unread messages.
 
+=head2 notifications
+
+  $int = $conversation->notifications;
+
+Holds the number of unread notifications.
+
 =head1 METHODS
 
 =head2 inc_unread_p
@@ -107,6 +120,12 @@ Holds the number of unread messages.
   $p = $conversation->inc_unread_p;
 
 Used to increase the unread count.
+
+=head2 inc_notifications_p
+
+  $p = $conversation->inc_notifications_p;
+
+Used to increate the unread notifications count.
 
 =head2 is_private
 

--- a/lib/Convos/Core/Conversation.pm
+++ b/lib/Convos/Core/Conversation.pm
@@ -38,7 +38,7 @@ sub _calculate_unread_p {
 
 sub TO_JSON {
   my ($self, $persist) = @_;
-  my %json = map { ($_, $self->$_) } qw(frozen name topic unread notifications);
+  my %json = map { ($_, $self->$_) } qw(frozen name topic notifications unread);
   $json{connection_id}   = $self->connection->id;
   $json{conversation_id} = $self->id;
   $json{last_read}       = $self->{last_read} if $self->{last_read};    # back compat

--- a/t/irc-events.t
+++ b/t/irc-events.t
@@ -126,6 +126,7 @@ cmp_deeply(
         name            => '#convos',
         topic           => 'Too cool!',
         unread          => 0,
+        notifications   => 0,
       }
     ]
   ),

--- a/t/irc-message.t
+++ b/t/irc-message.t
@@ -30,7 +30,9 @@ $server->client($connection)->server_event_ok('_irc_event_nick')->server_write_o
   ->client_event_ok('_irc_event_privmsg')->process_ok;
 
 note 'notifications';
-is $user->unread, 0, 'notifications';
+my $n_count_o = 0;
+$connection->conversations->map(sub { $n_count_o += $_->notifications; });
+is $n_count_o, 0, 'notifications';
 like slurp_log('#convos'), qr{\Q<Supergirl> not a superdupersuperman?\E}m, 'normal message';
 
 $server->server_write_ok(
@@ -60,7 +62,9 @@ my $notifications;
 $core->get_user('superman@example.com')->notifications_p({})->then(sub { $notifications = pop; })
   ->$wait_success('notifications');
 ok delete $notifications->{messages}[0]{ts}, 'notifications has timestamp';
-is $user->unread, 1, 'One unread messages';
+my $n_count = 0;
+$connection->conversations->map(sub { $n_count += $_->notifications; });
+is $n_count, 1, 'One unread messages';
 is_deeply(
   $notifications->{messages},
   [{
@@ -106,7 +110,9 @@ is_deeply(
   ],
   'notifications'
 );
-is $user->unread, 3, 'One unread messages';
+my $n_count_h = 0;
+$connection->conversations->map(sub { $n_count_h += $_->notifications; });
+is $n_count_h, 3, 'Three unread messages';
 
 $server->server_write_ok(":Supergirl!sg\@example.com PRIVMSG superman :does this work?!\r\n")
   ->client_event_ok('_irc_event_privmsg')->process_ok;

--- a/t/irc-message.t
+++ b/t/irc-message.t
@@ -55,7 +55,7 @@ $server->server_write_ok(
 {
   my $log = slurp_log('#convos');
   like $log, qr{\Q<Supergirl> But... SUPERMAN, what about in a channel?\E}s, 'notification';
-  like $log, qr/\x0307Wikinews:Sandbox\x03/s,                                'colors';
+  like $log, qr/\x0307Wikinews:Sandbox\x03/s, 'colors';
 }
 
 my $notifications;

--- a/t/web-conversation.t
+++ b/t/web-conversation.t
@@ -29,9 +29,35 @@ $t->get_ok('/api/conversations')->status_is(200)->json_is(
       name            => '#Convos',
       topic           => '',
       unread          => 42,
+      notifications   => 0,
     },
   ]
 );
+
+$connection->conversation({name => '#Notified', frozen => ''})->notifications(2);
+$t->get_ok('/api/conversations')->status_is(200)->json_is(
+  '/conversations' => [
+    {
+      connection_id   => 'irc-localhost',
+      conversation_id => '#convos',
+      frozen          => '',
+      name            => '#Convos',
+      topic           => '',
+      unread          => 42,
+      notifications   => 0,
+    },
+    {
+      connection_id   => 'irc-localhost',
+      conversation_id => '#notified',
+      frozen          => '',
+      name            => '#Notified',
+      topic           => '',
+      unread          => 0,
+      notifications   => 2,
+    },
+  ]
+);
+
 
 $user->connection({url => 'irc://example'})->conversation({name => '#superheroes', frozen => ''})
   ->unread(34);
@@ -70,6 +96,16 @@ $t->get_ok('/api/user?connections=true&conversations=true')->status_is(200)->jso
       name            => '#Convos',
       topic           => '',
       unread          => 42,
+      notifications   => 0,
+    },
+    {
+      connection_id   => 'irc-localhost',
+      conversation_id => '#notified',
+      frozen          => '',
+      name            => '#Notified',
+      topic           => '',
+      unread          => 0,
+      notifications   => 2,
     },
     {
       connection_id   => 'irc-example',
@@ -78,6 +114,7 @@ $t->get_ok('/api/user?connections=true&conversations=true')->status_is(200)->jso
       name            => '#superheroes',
       topic           => '',
       unread          => 34,
+      notifications   => 0,
     }
   ],
   'user conversations'


### PR DESCRIPTION
Store unread notification count per conversation object, assemble a count of those for the sidebar display. Dismiss / set to zero (for that channel) when a user visits a channel that has notifications.

I'm missing a sane way to test this in __tests__ as it requires both User + Notifications objs, any ideas?