### PR TITLE
Add arm64 docker image build support

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,16 +18,15 @@ jobs:
       run: |
         if echo $GITHUB_REF | grep -q '^refs/tags/v'; then
           VERSION=$(echo $GITHUB_REF | cut -d/ -f3);
-          TAG_NAME="convos/convos:$VERSION";
+          TAG_NAME="${{ secrets.DOCKER_HUB_USERNAME }}/convos:$VERSION";
         elif [ "$GITHUB_REF" = "refs/heads/docker" ]; then
-          TAG_NAME="convos/convos:alpha";
+          TAG_NAME="${{ secrets.DOCKER_HUB_USERNAME }}/convos:alpha";
         elif [ "$GITHUB_REF" = "refs/heads/master" ]; then
-          TAG_NAME="convos/convos:alpha";
+          TAG_NAME="${{ secrets.DOCKER_HUB_USERNAME }}/convos:alpha";
         else
-          TAG_NAME="convos/convos:stable";
+          TAG_NAME="${{ secrets.DOCKER_HUB_USERNAME }}/convos:stable";
         fi
         echo '::set-output name=tag::'$TAG_NAME
-
     - name: Check Out Repo
       uses: actions/checkout@v1
 
@@ -36,6 +35,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
 
     - name: Set up Docker Buildx
       id: buildx
@@ -48,6 +50,7 @@ jobs:
         context: ./
         file: ./Dockerfile
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.calculate_tag.outputs.tag }}
 
     - name: Image digest


### PR DESCRIPTION
This commit adds support for building arm64 images (should also be easy to add other architectures) with GitHub Actions. (Issue reference: #464). This action will generate both amd64 and arm64 images.

It also swaps out the hardcoded "convos/convos" URL for the secret `DOCKER_HUB_USERNAME`/convos which simplifies forks.

I've deployed the resultant container on a Raspberry Pi4 with Ubuntu Server 21.04 and all appears to work just fine. Container here: https://hub.docker.com/r/eugenedb/convos