### PR TITLE
Add Dockerhub prefix variable for tag in Github action

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,16 +18,15 @@ jobs:
       run: |
         if echo $GITHUB_REF | grep -q '^refs/tags/v'; then
           VERSION=$(echo $GITHUB_REF | cut -d/ -f3);
-          TAG_NAME="convos/convos:$VERSION";
+          TAG_NAME="${{ secrets.DOCKER_HUB_PREFIX }}/convos:$VERSION";
         elif [ "$GITHUB_REF" = "refs/heads/docker" ]; then
-          TAG_NAME="convos/convos:alpha";
+          TAG_NAME="${{ secrets.DOCKER_HUB_PREFIX }}/convos:alpha";
         elif [ "$GITHUB_REF" = "refs/heads/master" ]; then
-          TAG_NAME="convos/convos:alpha";
+          TAG_NAME="${{ secrets.DOCKER_HUB_PREFIX }}/convos:alpha";
         else
-          TAG_NAME="convos/convos:stable";
+          TAG_NAME="${{ secrets.DOCKER_HUB_PREFIX }}/convos:stable";
         fi
         echo '::set-output name=tag::'$TAG_NAME
-
     - name: Check Out Repo
       uses: actions/checkout@v1
 
@@ -36,6 +35,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
 
     - name: Set up Docker Buildx
       id: buildx
@@ -48,6 +50,7 @@ jobs:
         context: ./
         file: ./Dockerfile
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.calculate_tag.outputs.tag }}
 
     - name: Image digest


### PR DESCRIPTION
This will fix my assumption in #618 that the Dockerhub username is the same name used as the Docker package prefix.

This requires a new secret `DOCKER_HUB_PREFIX` to be added to the repository. In this case `DOCKER_HUB_PREFIX`=`convos`.

Apologies for not realising this sooner!