### PR TITLE
Fix unnecessary rehashing in `$user->validate_password`

### DIFF
--- a/lib/Convos/Core/User.pm
+++ b/lib/Convos/Core/User.pm
@@ -153,7 +153,7 @@ sub validate_password {
 
   return 0 unless $self->password and $plain;
   my $valid = $self->_crypt->verify_password($plain, $self->password);
-  if ($valid && $self->_crypt->needs_rehash($plain)) {
+  if ($valid && $self->_crypt->needs_rehash($self->password)) {
     $self->{password} = $self->_crypt->hash_password($plain);
   }
   return $valid;

--- a/t/user.t
+++ b/t/user.t
@@ -55,8 +55,10 @@ subtest 'password' => sub {
   ok $user->password, 'password';
   like $user->password, qr/^\$argon2id/, "password is hashed with argon2id";
 
+  my $password_hash = $user->{password};
   ok !$user->validate_password('s3crett'), 'invalid password';
   ok $user->validate_password('s3cret'), 'validate_password';
+  is $user->password, $password_hash, "validate_password does not needlessly rehash password";
 
   $user->save_p->$wait_success('save_p');
   is $core->get_user('jhthorsen@cpan.org')->password, $user->password, 'password from storage file';


### PR DESCRIPTION
Crypt::Passphrase::needs_rehash() was passed the plaintext password rather than the hash causing a rehash on every successful login attempt.