### PR TITLE
gha: build docker image for linux/arm/v7 (RPi 3)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:stable,${{ steps.calculate_tag.outputs.tag }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
I tried to run convos-chat on my RPi 3B+, but found out that there are no docker images for linux/arm/v7.

Built the image via buildx locally on my laptop and it's running fine on the RPi 3B+.

Depends on https://github.com/convos-chat/docker-base/pull/24