### PR TITLE
gha: add linux/arm/v7 to alpha

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/build-push-action@v5.0.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpha
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
In #863, I forgot to add linux/arm/v7 to the alpha workflow.

Fixes https://github.com/convos-chat/convos/issues/864.