### PR TITLE
fix segfaults in docker containers built for the wrong architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY script /app/script
 COPY templates /app/templates
 
 ENV CONVOS_DEPENDENCIES all
+ENV CRYPT_ARGON2_ARCH=NONE
 RUN apk add --no-cache curl openssl perl perl-io-socket-ssl perl-net-ssleay wget && \
   apk add --no-cache --virtual builddeps build-base perl-dev && \
   /app/script/convos install --all && \

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,7 @@ my @PREREQS = (
   [recommended => 'IO::Socket::Socks',  '0.64'],                 # non-blocking
   [core        => 'Crypt::Passphrase'            => '0.019'],    # password
   [core        => 'Crypt::Passphrase::Argon2'    => '0.009'],    # password
+  [core        => 'Crypt::Argon2'                => '0.022'],    # password
   [core        => 'Crypt::Passphrase::Bcrypt'    => '0.008'],    # password
   [core        => 'File::HomeDir'                => '1.00'],     # core
   [core        => 'File::ReadBackwards'          => '1.06'],     # backend file


### PR DESCRIPTION
On certain architectures, when Crypt::Argon2 is built for `-march=native` but then run on a different architecture (which is easy to do when building on say github actions then deploying elsewhere) the resulting build of the library will segfault when convos attempts to login, killing the container.

Since Crypt::Argon2 version 0.22 an environment variable is available that allows building without the `-march=native` optimization (when set to NONE).

Fixes #885